### PR TITLE
Fix usage of manually selected RPC

### DIFF
--- a/Assets/Scripts/Wallet/AccountManager.cs
+++ b/Assets/Scripts/Wallet/AccountManager.cs
@@ -269,6 +269,9 @@ namespace Poltergeist
             var url = $"http://soul.neoeconomy.io/getpeers.json";
             Settings.phantasmaRPCURL = Settings.phantasmaBPURL;
 
+            if (Settings.nexusKind == NexusKind.Custom)
+                return; // No need to change RPC, it is set by custom settings.
+
             StartCoroutine(
                 WebClient.RESTRequest(url, (error, msg) =>
                 {


### PR DESCRIPTION
Poltergeist do not use manually set RPCs. It selects one randomly even if "Custom" settings are applied. This check fixes it.