### PR TITLE
Autofocus dialog fields when using desktop version

### DIFF
--- a/Assets/Scripts/Wallet/WalletGUI.cs
+++ b/Assets/Scripts/Wallet/WalletGUI.cs
@@ -836,7 +836,7 @@ namespace Poltergeist
             {
                 GUI.SetNextControlName("PoltergeistModalPasswordField");
                 modalInput = GUI.PasswordField(new Rect(rect.x, curY, fieldWidth, Units(2)), modalInput, '*', modalMaxInputLength);
-                GUI.FocusControl("PoltergeistModalTextField");
+                GUI.FocusControl("PoltergeistModalPasswordField");
             }
 
             int btnWidth = VerticalLayout ? Units(7) : Units(11);

--- a/Assets/Scripts/Wallet/WalletGUI.cs
+++ b/Assets/Scripts/Wallet/WalletGUI.cs
@@ -820,17 +820,23 @@ namespace Poltergeist
             {
                 if (modalMaxLines > 1)
                 {
+                    GUI.SetNextControlName("PoltergeistModalTextArea");
                     modalInput = GUI.TextArea(new Rect(rect.x, curY, fieldWidth, Units(2) * modalMaxLines), modalInput, modalMaxInputLength);
+                    GUI.FocusControl("PoltergeistModalTextArea");
                 }
                 else
                 {
+                    GUI.SetNextControlName("PoltergeistModalTextField");
                     modalInput = GUI.TextField(new Rect(rect.x, curY, fieldWidth, Units(2)), modalInput, modalMaxInputLength);
+                    GUI.FocusControl("PoltergeistModalTextField");
                 }
             }
             else
             if (modalState == ModalState.Password)
             {
-                modalInput = GUI.PasswordField(new Rect(rect.x, curY, fieldWidth, Units(2)), modalInput, '*', modalMaxInputLength);               
+                GUI.SetNextControlName("PoltergeistModalPasswordField");
+                modalInput = GUI.PasswordField(new Rect(rect.x, curY, fieldWidth, Units(2)), modalInput, '*', modalMaxInputLength);
+                GUI.FocusControl("PoltergeistModalTextField");
             }
 
             int btnWidth = VerticalLayout ? Units(7) : Units(11);


### PR DESCRIPTION
It's much more convinient when fields in dialogs are focused by default when using desktop version on PC with keyboard.

Modification does not add anything to mobile version behavior (tested on Android 9), but it's not really important for mobile version.